### PR TITLE
Handle blank frames correctly in the frame stream process

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lasy"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A cross-platform laser DAC detection and streaming API."
 edition = "2018"

--- a/src/stream/frame/mod.rs
+++ b/src/stream/frame/mod.rs
@@ -396,7 +396,20 @@ impl Requester {
 
             // Join the inter-frame points with the interpolated frame.
             let interp_conf = &state.interpolation_conf;
-            let interpolated = opt::interpolate_euler_circuit(&ec, &eg, target_points, interp_conf);
+            let mut interpolated =
+                opt::interpolate_euler_circuit(&ec, &eg, target_points, interp_conf);
+
+            // If the interpolated frame is empty there were no lit points or lines.
+            // In this case, we'll produce an empty frame.
+            if interpolated.is_empty() {
+                let blank_frame = (0..target_points).map(|_| {
+                    self.last_frame_point
+                        .map(|p| p.blanked())
+                        .unwrap_or_else(RawPoint::centered_blank)
+                });
+                interpolated.extend(blank_frame);
+            }
+
             self.raw_points.extend(inter_frame_blank_points);
             self.raw_points.extend(interpolated);
 


### PR DESCRIPTION
If the interpolator returns an empty list of points due to a lack of lit
segments, the stream will now submit a frame of blank points to properly
account for this.

Closes #1.