### PR TITLE
 Handle case where the user submits an empty frame

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lasy"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A cross-platform laser DAC detection and streaming API."
 edition = "2018"


### PR DESCRIPTION
Empty frames now result in a frame full of blank points at either the
last position a point was emitted or in the centre of the field if none
have yet been emitted.