### PR TITLE
Allow for processing raw points of frame stream

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,16 @@ impl Lasy {
         let builder = Default::default();
         let frame_hz = None;
         let interpolation_conf = Default::default();
-        stream::frame::Builder { api_inner, builder, model, render, frame_hz, interpolation_conf }
+        let process_raw = stream::frame::default_process_raw_fn;
+        stream::frame::Builder {
+            api_inner,
+            builder,
+            model,
+            render,
+            process_raw,
+            frame_hz,
+            interpolation_conf,
+        }
     }
 
     /// Begin building a new laser raw stream.


### PR DESCRIPTION
This allows specifying a function that can be called for processing the
raw points of the frame stream that are output from the optimisation and
interpolation pass. See the docs for the new method for possible
use-cases and further details.