### PR TITLE
Rename crate from "lasy" to "nannou_laser"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nannou_laser"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A cross-platform laser DAC detection and streaming API."
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "lasy"
+name = "nannou_laser"
 version = "0.2.4"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A cross-platform laser DAC detection and streaming API."
 edition = "2018"
 keywords = ["laser", "dac", "stream", "frame", "ether-dream"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/nannou-org/lasy.git"
-homepage = "https://github.com/nannou-org/lasy"
+repository = "https://github.com/nannou-org/nannou_laser.git"
+homepage = "https://github.com/nannou-org/nannou_laser"
 
 [dependencies]
 derive_more = "0.14"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# lasy [![Build Status](https://travis-ci.org/nannou-org/lasy.svg?branch=master)](https://travis-ci.org/nannou-org/lasy) [![Crates.io](https://img.shields.io/crates/v/lasy.svg)](https://crates.io/crates/lasy) [![Crates.io](https://img.shields.io/crates/l/lasy.svg)](https://github.com/nannou-org/lasy/blob/master/LICENSE-MIT) [![docs.rs](https://docs.rs/lasy/badge.svg)](https://docs.rs/lasy/)
+# nannou_laser [![Build Status](https://travis-ci.org/nannou-org/nannou_laser.svg?branch=master)](https://travis-ci.org/nannou-org/nannou_laser) [![Crates.io](https://img.shields.io/crates/v/nannou_laser.svg)](https://crates.io/crates/nannou_laser) [![Crates.io](https://img.shields.io/crates/l/nannou_laser.svg)](https://github.com/nannou-org/nannou_laser/blob/master/LICENSE-MIT) [![docs.rs](https://docs.rs/nannou_laser/badge.svg)](https://docs.rs/nannou_laser/)
 
 A cross-platform laser DAC detection and streaming API.
 
-**lasy** aims to be a higher-level API around a variety of laser protocols
+**nannou_laser** aims to be a higher-level API around a variety of laser protocols
 providing a unified interface for detecting DACs and streaming data to them.
 
 ## Features
@@ -16,23 +16,24 @@ providing a unified interface for detecting DACs and streaming data to them.
 - **Raw Streams**: While frame streams are convenient, sometimes direct access
   to the lower-level raw DAC stream is required (e.g. when visualising a raw
   audio stream). This can be accessed via the **RawStream** API.
-- **Frame Optimisation**: **lasy** implements the full suite of optimisations
-  covered in *Accurate and Efficient Drawing Method for Laser Projection* by
-  Purkhet Abderyim et al. These include Graph optimisation, draw order
-  optimisation, blanking delays and sharp angle delays. See [the
+- **Frame Optimisation**: **nannou_laser** implements the full suite of
+  optimisations covered in *Accurate and Efficient Drawing Method for Laser
+  Projection* by Purkhet Abderyim et al. These include Graph optimisation, draw
+  order optimisation, blanking delays and sharp angle delays. See [the
   paper](https://art-science.org/journal/v7n4/v7n4pp155/artsci-v7n4pp155.pdf)
   for more details.
 - **Custom frame rate**: Choose the rate at which you wish to present frames.
-  **lasy** will determine the number of points used to draw each frame using the
-  connected DAC's points-per-second.
+  **nannou_laser** will determine the number of points used to draw each frame
+  using the connected DAC's points-per-second.
 
 *Note: Higher level features like pattern generators and frame graphs are out of
-scope for lasy, though could be built downstream. The priority for this crate is
-easy laser DAC detection and high-quality, high-performance data streams.*
+scope for nannou_laser, though could be built downstream. The priority for this
+crate is easy laser DAC detection and high-quality, high-performance data
+streams.*
 
 ## Supported Protocols
 
-Currently, **lasy** only supports the open source [Ether Dream
+Currently, **nannou_laser** only supports the open source [Ether Dream
 DAC](https://ether-dream.com/) protocol. The plan is to progressively add
 support for more protocols as they are needed by ourselves and users throughout
 the lifetime of the project.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,11 +19,11 @@ use std::sync::Arc;
 
 /// A general API that allows for detecting and enumerating laser DACs on a network and
 /// establishing new streams of communication with them.
-pub struct Lasy {
+pub struct Api {
     inner: Arc<Inner>,
 }
 
-// The inner state of the `Lasy` that can be easily shared between laser threads in an `Arc`.
+// The inner state of the `Api` that can be easily shared between laser threads in an `Arc`.
 //
 // This is useful for allowing streams to re-scan and find their associated DAC in the case it
 // drops out for some reason.
@@ -54,10 +54,10 @@ pub enum DacId {
     }
 }
 
-impl Lasy {
+impl Api {
     /// Instantiate the laser API.
     pub fn new() -> Self {
-        Lasy { inner: Arc::new(Inner) }
+        Api { inner: Arc::new(Inner) }
     }
 
     /// An iterator yielding laser DACs available on the system as they are discovered.
@@ -116,7 +116,7 @@ impl Lasy {
 }
 
 impl Inner {
-    // See the `Lasy::detect_dacs` docs.
+    // See the `Api::detect_dacs` docs.
     pub(crate) fn detect_dacs(&self) -> io::Result<DetectDacs> {
         let dac_broadcasts = ether_dream::recv_dac_broadcasts()?;
         Ok(DetectDacs { dac_broadcasts })


### PR DESCRIPTION
This follows the convention introduced by the "nannou_audio" crate in
order to simplify the organisation naming and make it easier for users
to find what they're looking for.