### PR TITLE
Implement a foreign function interface for the nannou_laser API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/nannou-org/nannou_laser.git"
 homepage = "https://github.com/nannou-org/nannou_laser"
 
+[lib]
+name = "nannou_laser"
+crate-type = ["rlib", "staticlib", "cdylib"]
+
 [dependencies]
 derive_more = "0.14"
 failure = "0.1"

--- a/examples/ffi.rs
+++ b/examples/ffi.rs
@@ -1,0 +1,211 @@
+//! An example of using `nannou_laser`'s `ffi`.
+//!
+//! While this example is in rust and not C, it should give an idea how to use the API via C.
+
+#[repr(C)]
+struct CallbackData {
+    pattern: u32,
+}
+
+type Pattern = u32;
+const RECTANGLE: Pattern = 0;
+const TRIANGLE: Pattern = 1;
+const CROSSHAIR: Pattern = 2;
+const THREE_VERTICAL_LINES: Pattern = 3;
+const SPIRAL: Pattern = 4;
+const TOTAL_PATTERNS: u32 = SPIRAL + 1;
+
+fn main() {
+    unsafe {
+        // Create the API.
+        println!("Initialising API...");
+        let mut api = std::ptr::null_mut();
+        nannou_laser::ffi::api_new(&mut api);
+
+        // Detect DAC.
+        println!("Detecting DAC...");
+        let mut dac = std::mem::MaybeUninit::<nannou_laser::ffi::DetectedDac>::uninit();
+        let res = nannou_laser::ffi::detect_dac(api, dac.as_mut_ptr());
+        if res as u32 != 0 {
+            eprintln!("failed to detect DAC");
+            nannou_laser::ffi::api_drop(api);
+            return;
+        }
+        let dac = dac.assume_init();
+        println!("Found DAC!");
+
+        // Only ether dream supported presently.
+        let ether_dream = dac.kind.ether_dream;
+        println!("{:#?}", ether_dream);
+
+        // Create a frame stream.
+        let mut frame_stream_conf = std::mem::MaybeUninit::<nannou_laser::ffi::FrameStreamConfig>::uninit();
+        nannou_laser::ffi::frame_stream_config_default(frame_stream_conf.as_mut_ptr());
+        let frame_stream_conf = frame_stream_conf.assume_init();
+        let callback_data: *mut CallbackData = Box::into_raw(Box::new(CallbackData { pattern: RECTANGLE }));
+        let mut frame_stream = std::ptr::null_mut();
+        println!("Spawning new frame stream...");
+        nannou_laser::ffi::new_frame_stream(
+            api,
+            &mut frame_stream,
+            &frame_stream_conf,
+            callback_data as *mut std::os::raw::c_void,
+            frame_render_callback,
+            process_raw_callback,
+        );
+
+        // Run through each pattern for 1 second.
+        for pattern in 0..TOTAL_PATTERNS {
+            println!("drawing pattern {}", pattern);
+            (*callback_data).pattern = pattern;
+            std::thread::sleep(std::time::Duration::from_secs(1));
+        }
+
+        // Drop frame stream to close it.
+        println!("Dropping the frame stream");
+        nannou_laser::ffi::frame_stream_drop(frame_stream);
+        std::mem::drop(Box::from_raw(callback_data));
+
+        // Create a raw stream.
+        let mut stream_conf = std::mem::MaybeUninit::<nannou_laser::ffi::StreamConfig>::uninit();
+        nannou_laser::ffi::stream_config_default(stream_conf.as_mut_ptr());
+        let stream_conf = stream_conf.assume_init();
+        let callback_data: *mut CallbackData = Box::into_raw(Box::new(CallbackData { pattern: RECTANGLE }));
+        let mut raw_stream = std::ptr::null_mut();
+        println!("Spawning a raw stream...");
+        nannou_laser::ffi::new_raw_stream(
+            api,
+            &mut raw_stream,
+            &stream_conf,
+            callback_data as *mut std::os::raw::c_void,
+            raw_render_callback,
+        );
+
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        // Drop the raw stream to close it.
+        println!("Dropping the raw stream");
+        nannou_laser::ffi::raw_stream_drop(raw_stream);
+        std::mem::drop(Box::from_raw(callback_data));
+
+        // Release the handle to the API when we're done.
+        println!("Cleaning up...");
+        nannou_laser::ffi::api_drop(api);
+
+        println!("Done!");
+    }
+}
+
+// Called when the stream is ready for a new frame of data.
+extern fn frame_render_callback(
+    data: *mut std::os::raw::c_void,
+    frame: *mut nannou_laser::ffi::Frame,
+) {
+    unsafe {
+        let data_ptr = data as *mut CallbackData;
+        let data = &mut *data_ptr;
+        let frame = &mut *frame;
+        write_laser_frame_points(data, frame);
+    }
+}
+
+fn write_laser_frame_points(data: &mut CallbackData, frame: &mut nannou_laser::ffi::Frame) {
+    // Simple constructors for white or blank points.
+    let lit_p = |position| nannou_laser::Point::new(position, [1.0; 3]);
+
+    // Draw the frame with the selected pattern.
+    match data.pattern {
+        RECTANGLE => {
+            let tl = [-1.0, 1.0];
+            let tr = [1.0, 1.0];
+            let br = [1.0, -1.0];
+            let bl = [-1.0, -1.0];
+            let positions = [tl, tr, br, bl, tl];
+            let points: Vec<_> = positions.iter().cloned().map(lit_p).collect();
+            unsafe {
+                nannou_laser::ffi::frame_add_lines(frame, points.as_ptr(), points.len());
+            }
+        }
+
+        TRIANGLE => {
+            let a = [-0.75, -0.75];
+            let b = [0.0, 0.75];
+            let c = [0.75, -0.75];
+            let positions = [a, b, c, a];
+            let points: Vec<_> = positions.iter().cloned().map(lit_p).collect();
+            unsafe {
+                nannou_laser::ffi::frame_add_lines(frame, points.as_ptr(), points.len());
+            }
+        }
+
+        CROSSHAIR => {
+            let xa = [-1.0, 0.0];
+            let xb = [1.0, 0.0];
+            let ya = [0.0, -1.0];
+            let yb = [0.0, 1.0];
+            let x = [lit_p(xa), lit_p(xb)];
+            let y = [lit_p(ya), lit_p(yb)];
+            unsafe {
+                nannou_laser::ffi::frame_add_lines(frame, x.as_ptr(), x.len());
+                nannou_laser::ffi::frame_add_lines(frame, y.as_ptr(), y.len());
+            }
+        }
+
+        THREE_VERTICAL_LINES => {
+            let la = [-1.0, -0.5];
+            let lb = [-1.0, 0.5];
+            let ma = [0.0, 0.5];
+            let mb = [0.0, -0.5];
+            let ra = [1.0, -0.5];
+            let rb = [1.0, 0.5];
+            let l = [lit_p(la), lit_p(lb)];
+            let m = [lit_p(ma), lit_p(mb)];
+            let r = [lit_p(ra), lit_p(rb)];
+            unsafe {
+                nannou_laser::ffi::frame_add_lines(frame, l.as_ptr(), l.len());
+                nannou_laser::ffi::frame_add_lines(frame, m.as_ptr(), m.len());
+                nannou_laser::ffi::frame_add_lines(frame, r.as_ptr(), r.len());
+            }
+        }
+
+        SPIRAL => {
+            let n_points = unsafe {
+                nannou_laser::ffi::points_per_frame(frame) as usize / 2
+            };
+            let radius = 1.0;
+            let rings = 5.0;
+            let points = (0..n_points)
+                .map(|i| {
+                    let fract = i as f32 / n_points as f32;
+                    let mag = fract * radius;
+                    let phase = rings * fract * 2.0 * std::f32::consts::PI;
+                    let y = mag * -phase.sin();
+                    let x = mag * phase.cos();
+                    [x, y]
+                })
+                .map(lit_p)
+                .collect::<Vec<_>>();
+            unsafe {
+                nannou_laser::ffi::frame_add_lines(frame, points.as_ptr(), points.len());
+            }
+        }
+
+        _ => unreachable!(),
+    }
+}
+
+// Called when the stream is ready for data. This is called after the `frame_render_callback` and
+// after all path optimisations have been applied. This is useful as a kind of post-processing
+// function, for applying safety zones, etc.
+extern fn process_raw_callback(
+    _data: *mut std::os::raw::c_void,
+    _buffer: *mut nannou_laser::ffi::Buffer,
+) {
+}
+
+// Called when then
+extern fn raw_render_callback(
+    _data: *mut std::os::raw::c_void,
+    _buffer: *mut nannou_laser::ffi::Buffer,
+) {
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,0 +1,325 @@
+//! Expose a C compatible interface.
+
+use std::ffi::{CStr, CString};
+use std::os::raw;
+
+#[repr(C)]
+pub struct Api {
+    inner: crate::Api,
+    last_error: Option<CString>,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct DetectedDac {
+    pub kind: DetectedDacKind,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union DetectedDacKind {
+    pub ether_dream: DacEtherDream,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct DacEtherDream {
+    pub broadcast: ether_dream::protocol::DacBroadcast,
+    pub source_addr: *const raw::c_char,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct StreamConfig {
+    pub detected_dac: *const DetectedDac,
+    pub point_hz: raw::c_uint,
+    pub latency_points: raw::c_uint,
+}
+
+#[repr(C)]
+pub struct FrameStream {
+    stream: FrameStreamInner,
+}
+
+#[repr(C)]
+pub struct RawStream {
+    stream: RawStreamInner,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub enum Result {
+    Success = 0,
+    FailedToDetectDac,
+    FailedToBuildStream,
+}
+
+#[repr(C)]
+#[derive(Clone, Debug)]
+pub struct FrameStreamConfig {
+    pub stream_conf: StreamConfig,
+    pub frame_hz: u32,
+    pub interpolation_conf: crate::stream::frame::opt::InterpolationConfig,
+}
+
+#[repr(C)]
+pub struct Frame<'a> {
+    frame: &'a mut crate::stream::frame::Frame,
+}
+
+#[repr(C)]
+pub struct Buffer<'a> {
+    buffer: &'a mut crate::stream::raw::Buffer,
+}
+
+struct FrameStreamModel(*mut raw::c_void, FrameRenderCallback, RawRenderCallback);
+struct RawStreamModel(*mut raw::c_void, RawRenderCallback);
+
+unsafe impl Send for FrameStreamModel {}
+unsafe impl Send for RawStreamModel {}
+
+type FrameStreamInner = crate::FrameStream<FrameStreamModel>;
+type RawStreamInner = crate::RawStream<RawStreamModel>;
+
+/// Cast to `extern fn(*mut raw::c_void, *mut Frame)` internally.
+//pub type FrameRenderCallback = *const raw::c_void;
+pub type FrameRenderCallback = extern fn(*mut raw::c_void, *mut Frame);
+/// Cast to `extern fn(*mut raw::c_void, *mut Buffer)` internally.
+//pub type RawRenderCallback = *const raw::c_void;
+pub type RawRenderCallback = extern fn(*mut raw::c_void, *mut Buffer);
+
+/// Given some uninitialized pointer to an `Api` struct, fill it with a new Api instance.
+#[no_mangle]
+pub unsafe extern fn api_new(api_ptr: *mut *mut Api) {
+    let inner = crate::Api::new();
+    let last_error = None;
+    let api = Api { inner, last_error };
+    let boxed_api = Box::new(api);
+    let new_api_ptr = Box::into_raw(boxed_api);
+    *api_ptr = new_api_ptr;
+}
+
+/// Block the current thread until a new DAC is detected and return it.
+#[no_mangle]
+pub unsafe extern fn detect_dac(api: *const Api, detected_dac: *mut DetectedDac) -> Result {
+    let api: &Api = &*api;
+    let mut iter = match api.inner.detect_dacs() {
+        Err(err) => {
+            unimplemented!()
+        },
+        Ok(iter) => iter,
+    };
+    match iter.next() {
+        None => return Result::FailedToDetectDac,
+        Some(res) => {
+            match res {
+                Ok(crate::DetectedDac::EtherDream { broadcast, source_addr }) => {
+                    let string = format!("{}", source_addr);
+                    let bytes = string.into_bytes();
+                    let source_addr = bytes.as_ptr() as *const raw::c_char;
+                    std::mem::forget(bytes);
+                    let ether_dream = DacEtherDream { broadcast, source_addr };
+                    let kind = DetectedDacKind { ether_dream };
+                    *detected_dac = DetectedDac { kind };
+                    return Result::Success;
+                }
+                Err(err) => {
+                    unimplemented!()
+                }
+            }
+        }
+    }
+}
+
+fn default_stream_config() -> StreamConfig {
+    let detected_dac = std::ptr::null();
+    let point_hz = crate::stream::DEFAULT_POINT_HZ;
+    let latency_points = crate::stream::raw::default_latency_points(point_hz);
+    StreamConfig {
+        detected_dac,
+        point_hz,
+        latency_points,
+    }
+}
+
+/// Initialise the given frame stream configuration with default values.
+#[no_mangle]
+pub unsafe extern fn frame_stream_config_default(conf: *mut FrameStreamConfig) {
+    let stream_conf = default_stream_config();
+    let frame_hz = crate::stream::DEFAULT_FRAME_HZ;
+    let interpolation_conf = crate::stream::frame::opt::InterpolationConfig::start().build();
+    *conf = FrameStreamConfig {
+        stream_conf,
+        frame_hz,
+        interpolation_conf,
+    };
+}
+
+/// Initialise the given raw stream configuration with default values.
+#[no_mangle]
+pub unsafe extern fn stream_config_default(conf: *mut StreamConfig) {
+    *conf = default_stream_config();
+}
+
+/// Spawn a new frame rendering stream.
+#[no_mangle]
+pub unsafe extern fn new_frame_stream(
+    api: *const Api,
+    stream: *mut *mut FrameStream,
+    config: *const FrameStreamConfig,
+    callback_data: *mut raw::c_void,
+    frame_render_callback: FrameRenderCallback,
+    process_raw_callback: RawRenderCallback,
+) -> Result {
+    let api: &Api = &*api;
+    let model = FrameStreamModel(callback_data, frame_render_callback, process_raw_callback);
+
+    fn render_fn(model: &mut FrameStreamModel, frame: &mut crate::stream::frame::Frame) {
+        let FrameStreamModel(callback_data_ptr, frame_render_callback, _) = *model;
+        let mut frame = Frame { frame };
+        frame_render_callback(callback_data_ptr, &mut frame);
+    }
+
+    let mut builder = api.inner.new_frame_stream(model, render_fn)
+        .point_hz((*config).stream_conf.point_hz as _)
+        .latency_points((*config).stream_conf.latency_points as _)
+        .frame_hz((*config).frame_hz as _);
+
+    fn process_raw_fn(model: &mut FrameStreamModel, buffer: &mut crate::stream::raw::Buffer) {
+        let FrameStreamModel(callback_data_ptr, _, process_raw_callback) = *model;
+        let mut buffer = Buffer { buffer };
+        process_raw_callback(callback_data_ptr, &mut buffer);
+    }
+
+    builder = builder.process_raw(process_raw_fn);
+
+    if (*config).stream_conf.detected_dac != std::ptr::null() {
+        let ffi_dac = (*(*config).stream_conf.detected_dac).clone();
+        let broadcast = ffi_dac.kind.ether_dream.broadcast.clone();
+        let source_addr_ptr = ffi_dac.kind.ether_dream.source_addr;
+        let source_addr = CStr::from_ptr(source_addr_ptr)
+            .to_string_lossy()
+            .parse()
+            .expect("failed to parse `source_addr`");
+        let detected_dac = crate::DetectedDac::EtherDream { broadcast, source_addr };
+        builder = builder.detected_dac(detected_dac);
+    }
+
+    let frame_stream = match builder.build() {
+        Err(err) => {
+            unimplemented!();
+            return Result::FailedToBuildStream;
+        },
+        Ok(stream) => Box::new(FrameStream { stream }),
+    };
+    *stream = Box::into_raw(frame_stream);
+    Result::Success
+}
+
+/// Spawn a new frame rendering stream.
+#[no_mangle]
+pub unsafe extern fn new_raw_stream(
+    api: *const Api,
+    stream: *mut *mut RawStream,
+    config: *const StreamConfig,
+    callback_data: *mut raw::c_void,
+    process_raw_callback: RawRenderCallback,
+) -> Result {
+    let api: &Api = &*api;
+    let model = RawStreamModel(callback_data, process_raw_callback);
+
+    fn render_fn(model: &mut RawStreamModel, buffer: &mut crate::stream::raw::Buffer) {
+        let RawStreamModel(callback_data_ptr, raw_render_callback) = *model;
+        let mut buffer = Buffer { buffer };
+        raw_render_callback(callback_data_ptr, &mut buffer);
+    }
+
+    let mut builder = api.inner.new_raw_stream(model, render_fn)
+        .point_hz((*config).point_hz as _)
+        .latency_points((*config).latency_points as _);
+
+    if (*config).detected_dac != std::ptr::null() {
+        let ffi_dac = (*(*config).detected_dac).clone();
+        let broadcast = ffi_dac.kind.ether_dream.broadcast.clone();
+        let source_addr_ptr = ffi_dac.kind.ether_dream.source_addr;
+        let source_addr = CStr::from_ptr(source_addr_ptr)
+            .to_string_lossy()
+            .parse()
+            .expect("failed to parse `source_addr`");
+        let detected_dac = crate::DetectedDac::EtherDream { broadcast, source_addr };
+        builder = builder.detected_dac(detected_dac);
+    }
+
+    let raw_stream = match builder.build() {
+        Err(err) => {
+            unimplemented!();
+            return Result::FailedToBuildStream;
+        },
+        Ok(stream) => Box::new(RawStream { stream }),
+    };
+    *stream = Box::into_raw(raw_stream);
+
+    Result::Success
+}
+
+/// Add a sequence of consecutive points separated by blank space.
+///
+/// If some points already exist in the frame, this method will create a blank segment between the
+/// previous point and the first point before appending this sequence.
+#[no_mangle]
+pub unsafe extern fn frame_add_points(frame: *mut Frame, points: *const crate::Point, len: usize) {
+    let frame = &mut *frame;
+    let points = std::slice::from_raw_parts(points, len);
+    frame.frame.add_points(points.iter().cloned());
+}
+
+/// Add a sequence of consecutive lines.
+///
+/// If some points already exist in the frame, this method will create a blank segment between the
+/// previous point and the first point before appending this sequence.
+#[no_mangle]
+pub unsafe extern fn frame_add_lines(frame: *mut Frame, points: *const crate::Point, len: usize) {
+    let frame = &mut *frame;
+    let points = std::slice::from_raw_parts(points, len);
+    frame.frame.add_lines(points.iter().cloned());
+}
+
+pub unsafe extern fn frame_hz(frame: *const Frame) -> u32 {
+    (*frame).frame.frame_hz()
+}
+
+pub unsafe extern fn frame_point_hz(frame: *const Frame) -> u32 {
+    (*frame).frame.point_hz()
+}
+
+pub unsafe extern fn frame_latency_points(frame: *const Frame) -> u32 {
+    (*frame).frame.latency_points()
+}
+
+pub unsafe extern fn points_per_frame(frame: *const Frame) -> u32 {
+    (*frame).frame.latency_points()
+}
+
+/// Must be called in order to correctly clean up the frame stream.
+#[no_mangle]
+pub unsafe extern fn frame_stream_drop(stream_ptr: *mut FrameStream) {
+    if stream_ptr != std::ptr::null_mut() {
+        Box::from_raw(stream_ptr);
+    }
+}
+
+/// Must be called in order to correctly clean up the raw stream.
+#[no_mangle]
+pub unsafe extern fn raw_stream_drop(stream_ptr: *mut RawStream) {
+    if stream_ptr != std::ptr::null_mut() {
+        Box::from_raw(stream_ptr);
+    }
+}
+
+/// Must be called in order to correctly clean up the API resources.
+#[no_mangle]
+pub unsafe extern fn api_drop(api_ptr: *mut Api) {
+    if api_ptr != std::ptr::null_mut() {
+        Box::from_raw(api_ptr);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub extern crate ether_dream;
 
+pub mod ffi;
 pub mod lerp;
 pub mod point;
 pub mod stream;

--- a/src/point.rs
+++ b/src/point.rs
@@ -15,6 +15,7 @@ pub type Rgb = [f32; 3];
 ///
 /// If two consecutive points have two different colours, the `color` values will be linearly
 /// interpolated.
+#[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Point {
     /// The position of the point. `-1` represents the minimum value along the axis and `1`
@@ -37,6 +38,7 @@ pub struct Point {
 ///
 /// If two consecutive points have two different colours, the `color` values will be linearly
 /// interpolated.
+#[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct RawPoint {
     /// The position of the point. `-1` represents the minimum value along the axis and `1`

--- a/src/stream/frame/mod.rs
+++ b/src/stream/frame/mod.rs
@@ -27,7 +27,7 @@ struct State {
 }
 
 // Updates for the interpolation config sent from the stream handle to the laser thread.
-type StateUpdate = Box<FnMut(&mut State) + 'static + Send>;
+type StateUpdate = Box<dyn FnMut(&mut State) + 'static + Send>;
 
 /// A wrapper around the `Vec` of points being collected for the frame.
 ///

--- a/src/stream/frame/opt.rs
+++ b/src/stream/frame/opt.rs
@@ -43,6 +43,7 @@ pub struct Segments<I> {
 }
 
 /// Configuration options for eulerian circuit interpolation.
+#[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct InterpolationConfig {
     /// The minimum distance the interpolator can travel along an edge before a new point is

--- a/src/stream/raw.rs
+++ b/src/stream/raw.rs
@@ -57,10 +57,10 @@ pub struct Builder<M, F> {
 }
 
 // The type used for sending state updates from the stream handle thread to the laser thread.
-type StateUpdate = Box<FnMut(&mut State) + 'static + Send>;
+type StateUpdate = Box<dyn FnMut(&mut State) + 'static + Send>;
 
 /// The type used for sending model updates from the stream handle thread to the laser thread.
-pub type ModelUpdate<M> = Box<FnMut(&mut M) + 'static + Send>;
+pub type ModelUpdate<M> = Box<dyn FnMut(&mut M) + 'static + Send>;
 
 /// Errors that may occur while running a laser stream.
 #[derive(Debug, Fail, From)]


### PR DESCRIPTION
This should allow non Rust programs to use `nannou_laser`! There aren't a lot of nice open source LASER solutions out there currently, so hopefully some folks find this useful.

Also includes an `ffi.rs` example demonstrating the usage by writing
Rust code in a C style.

Still need to:

- [ ] Generate a C header from FFI fns.
- [ ] Do a review to ensure whole API is covered.
- [ ] Maybe add an async "detect_dacs" function via callback.